### PR TITLE
Fixes dispose all on null

### DIFF
--- a/lib/motion_widget.dart
+++ b/lib/motion_widget.dart
@@ -149,7 +149,7 @@ class _MotionState<T extends Flex> extends State<Motion<T>>
 
   @override
   void dispose() {
-    widget.motionController.dispose();
+    widget.motionController?.dispose();
     widget.exitConfigurations?.controller?.dispose();
 
     super.dispose();


### PR DESCRIPTION
I was not able to find out why the _motionController_ is NULL because in my case the whole component might have been initialized fully and the motionController might have been setup completely.

This PR fixes the exception on issue #1

I used motion_widgeet within a bottom tab bar content pane